### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -18,8 +18,8 @@ data_pin	KEYWORD2
 read	KEYWORD2
 report	KEYWORD2
 write	KEYWORD2
-enable KEYWORD2
-disable KEYWORD2
+enable	KEYWORD2
+disable	KEYWORD2
 set_remote_mode	KEYWORD2
 set_stream_mode	KEYWORD2
 set_resolution	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords