### PR TITLE
included stdint.h to fix "'int8_t' does not name a type" and similar errors

### DIFF
--- a/PS2Mouse.h
+++ b/PS2Mouse.h
@@ -1,3 +1,5 @@
+#include <stdint.h>
+
 #ifndef PS2Mouse_h
 
 #define PS2Mouse_h


### PR DESCRIPTION
the Arduino IDE automatically adds some includes if needed (one of which is stdint.h), but only when compiling a .ino file. it needs to be explicitly included for the Arduino compiler to recognize those types in a .cpp file